### PR TITLE
Fix JSON RPC error. Block access to ground truth file. Clean unused code.

### DIFF
--- a/scenarios/opencaptchaworld/opencaptchaworld_judge.py
+++ b/scenarios/opencaptchaworld/opencaptchaworld_judge.py
@@ -195,20 +195,12 @@ async def serve_captcha_file(request):
     captcha_type = request.path_params['captcha_type']
     filename = request.path_params['filename']
     file_path = _safe_path(captcha_type, filename)
-    
-    if file_path and file_path.exists():
-        return FileResponse(file_path)
-    return JSONResponse({'error': 'File not found'}, status_code=404)
 
-
-async def serve_captcha_subdir_file(request):
-    """Serve CAPTCHA image files from subdirectories."""
-    captcha_type = request.path_params['captcha_type']
-    subdir = request.path_params['subdir']
-    filename = request.path_params['filename']
-    file_path = _safe_path(captcha_type, subdir, filename)
-    
     if file_path and file_path.exists():
+        # Prevent leaking solutions by blocking direct access to ground_truth.json
+        if file_path.name == 'ground_truth.json':
+            logger.warning(f"Blocked access to ground truth file: {file_path}")
+            return JSONResponse({'error': 'File not available'}, status_code=403)
         return FileResponse(file_path)
     return JSONResponse({'error': 'File not found'}, status_code=404)
 

--- a/scenarios/opencaptchaworld/opencaptchaworld_solver.py
+++ b/scenarios/opencaptchaworld/opencaptchaworld_solver.py
@@ -158,7 +158,12 @@ class SimpleSolverExecutor:
             if not url or not url.startswith('http'):
                 logger.info(f"No URL found in message - treating as feedback-only message")
                 logger.info(f"Message content: {message_text[:200]}...")
-                # Don't send a response for feedback-only messages
+                # Send acknowledgment for feedback-only messages
+                ack_message = json.dumps({
+                    "status": "acknowledged",
+                    "message": "Feedback received"
+                })
+                await queue.enqueue_event(new_agent_text_message(text=ack_message))
                 return
 
             logger.info(f"Extracted URL: {url}")


### PR DESCRIPTION
Enhance feedback handling by sending acknowledgment for feedback-only messages to fix the JSON RPC error. 

Block access to ground truth file. 

Clean unused code.