### PR TITLE
Click Order UX Updates: add persistent numbered markers and a reset-click button

### DIFF
--- a/assets/opencaptchaworld/static/css/style.css
+++ b/assets/opencaptchaworld/static/css/style.css
@@ -99,6 +99,49 @@ h1 {
     width: 200px;
 }
 
+#download-result {
+    padding: 10px 20px;
+    background-color: #2196F3;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background-color 0.3s;
+}
+
+#download-result:hover {
+    background-color: #0b7dda;
+}
+
+#download-result:disabled {
+    background-color: #95a5a6;
+    cursor: not-allowed;
+}
+
+#reset-clicks {
+    margin: 0 auto;
+    margin-top: 5px;
+    padding: 10px 20px;
+    background-color: #f44336;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background-color 0.3s;
+    display: none;
+}
+
+#reset-clicks:hover {
+    background-color: #d32f2f;
+}
+
+#reset-clicks:disabled {
+    background-color: #f8bdbd;
+    cursor: not-allowed;
+}
+
 #submit-answer {
     padding: 10px 20px;
     background-color: #2ecc71;
@@ -161,6 +204,25 @@ h1 {
         transform: translate(-50%, -50%) scale(1.2);
         box-shadow: 0 0 0 10px rgba(231, 76, 60, 0);
     }
+}
+
+.click-order-marker {
+    position: absolute;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: rgba(229, 57, 53, 0.92);
+    border: 2px solid #b71c1c;
+    color: #fff;
+    font-weight: 600;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 20;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 
 @media (max-width: 768px) {

--- a/assets/opencaptchaworld/templates/index2.html
+++ b/assets/opencaptchaworld/templates/index2.html
@@ -65,6 +65,7 @@
                     <input type="text" id="user-answer" placeholder="Your answer">
                     <button id="download-result">Download Result</button>
                 </div>
+                <button id="reset-clicks">Reset Clicks</button>
                 <div id="result-message" class="result-message"></div>
             </div>
         </div>


### PR DESCRIPTION
Click Order UX Updates

- assets/opencaptchaworld/static/js/script2.js now keeps dedicated click-order state, wires the Reset Clicks button, draws persistent numbered markers for each click, and limits button visibility/behavior to Click_Order puzzles so other puzzle types stay untouched.
- assets/opencaptchaworld/static/css/style.css styles the Download/Reset buttons and adds the red circular marker with a white number centered above each recorded click.
- assets/opencaptchaworld/templates/index2.html includes the Reset Clicks button in the base layout so it sits beneath Download Result and is ready for the Click_Order-specific toggle logic.