### PR TITLE
Enhance answer validation: support multiple areas for geometry click puzzles (fix puzzle geetest_000001)

### DIFF
--- a/assets/opencaptchaworld/data/Geometry_Click/ground_truth.json
+++ b/assets/opencaptchaworld/data/Geometry_Click/ground_truth.json
@@ -42,7 +42,11 @@
   "geetest_000001.jpg": {
     "answer": {
       "type": "circle",
-      "area": [[160, 90], [210, 125]]
+      "area": [[160, 90], [210, 125]],
+      "areas": [
+        [[160, 90], [210, 125]],
+        [[199, 123], [210, 160]]
+      ]
     },
     "prompt": "Click the yellow cylinder",
     "description": "Geometry click puzzle with various 3D shapes"

--- a/scenarios/opencaptchaworld/opencaptchaworld_judge.py
+++ b/scenarios/opencaptchaworld/opencaptchaworld_judge.py
@@ -254,6 +254,14 @@ def check_answer(puzzle_type: str, puzzle_id: str, user_answer, ground_truth_dat
         correct_answer = ground_truth_data.get('answer')
         try:
             user_x, user_y = user_answer
+            if isinstance(correct_answer, dict) and 'areas' in correct_answer:
+                for area in correct_answer['areas']:
+                    top_left, bottom_right = area
+                    min_x, min_y = top_left
+                    max_x, max_y = bottom_right
+                    if (min_x <= user_x <= max_x) and (min_y <= user_y <= max_y):
+                        return True, correct_answer
+                return False, correct_answer
             if isinstance(correct_answer, dict) and 'area' in correct_answer:
                 top_left, bottom_right = correct_answer['area']
                 min_x, min_y = top_left


### PR DESCRIPTION
Thanks to @xgong12 for pointing it out!

This PR fixes the puzzle geetest_000001 of type geometry click.

<img width="1126" height="691" alt="c186823c75200b7e7e8b8a78dfb0ef78" src="https://github.com/user-attachments/assets/23c24202-41c6-4cf1-ba7b-b9aa0d5c0a08" />
