### PR TITLE
Add Optional Patches to the Ground Truth for Multiple Patch_Select Puzzles

### DIFF
--- a/assets/opencaptchaworld/data/Patch_Select/ground_truth.json
+++ b/assets/opencaptchaworld/data/Patch_Select/ground_truth.json
@@ -3,6 +3,7 @@
     "target_object": "moon",
     "grid_size": [5, 5],
     "correct_patches": [0,1,2,3,5,6,7,8,11,12,13],
+    "optional_patches": [10],
     "prompt": "Select all squares with moon",
     "description": "A grid of 5x5 patches containing a moon"
   },
@@ -10,6 +11,7 @@
     "target_object": "butterfly",
     "grid_size": [5, 5],
     "correct_patches": [5,6,7,10,11,12,15,16],
+    "optional_patches": [17],
     "prompt": "Select all squares with butterfly",
     "description": "A grid of 5x5 patches containing a butterfly"
   },
@@ -24,6 +26,7 @@
     "target_object": "bird",
     "grid_size": [5, 5],
     "correct_patches": [3,6,7,8,12,13,14,18,19],
+    "optional_patches": [18, 19],
     "prompt": "Select all squares with bird",
     "description": "A grid of 5x5 patches containing a bird"
   },
@@ -38,6 +41,7 @@
     "target_object": "Red-crowned crane",
     "grid_size": [5, 5],
     "correct_patches": [0,1,2,3,4,5,6,7,8,9,11,12,13,14,16,18],
+    "optional_patches": [18],
     "prompt": "Select all squares with Red-crowned crane (a bird)",
     "description": "A grid of 5x5 patches containing a Red-crowned crane"
   },
@@ -59,6 +63,7 @@
     "target_object": "bench",
     "grid_size": [5, 5],
     "correct_patches": [16,17,18,21,22,23],
+    "optional_patches": [16, 17, 18],
     "prompt": "Select all squares with bench",
     "description": "A grid of 5x5 patches containing a bench"
   },
@@ -66,6 +71,7 @@
     "target_object": "bridge",
     "grid_size": [5, 5],
     "correct_patches": [17,18,21,22,23],
+    "optional_patches": [18],
     "prompt": "Select all squares with bridge",
     "description": "A grid of 5x5 patches containing a bridge"
   },
@@ -87,6 +93,7 @@
     "target_object": "boat",
     "grid_size": [5, 5],
     "correct_patches": [22,23],
+    "optional_patches": [17],
     "prompt": "Select all squares with boat",
     "description": "A grid of 5x5 patches containing a boat"
   },
@@ -101,6 +108,7 @@
     "target_object": "house",
     "grid_size": [5, 5],
     "correct_patches": [2,3,6,7,8,10,11],
+    "optional_patches": [12],
     "prompt": "Select all squares with house",
     "description": "A grid of 5x5 patches containing houses"
   },
@@ -115,6 +123,7 @@
     "target_object": "train",
     "grid_size": [5, 5],
     "correct_patches": [5,10,11,12,13,15,16,17,20,21],
+    "optional_patches": [6, 21],
     "prompt": "Select all squares with train",
     "description": "A grid of 5x5 patches containing trains"
   },
@@ -129,6 +138,7 @@
     "target_object": "firework",
     "grid_size": [5, 5],
     "correct_patches": [6,7,8,10,11,12,13,14,15,16,17,18,19,21,22,23],
+    "optional_patches": [9],
     "prompt": "Select all squares with firework",
     "description": "A grid of 5x5 patches containing fireworks"
   },
@@ -136,6 +146,7 @@
     "target_object": "windmill",
     "grid_size": [5, 5],
     "correct_patches": [7,10,12,14,16,17,18,19],
+    "optional_patches": [6, 8, 11],
     "prompt": "Select all squares with windmill",
     "description": "A grid of 5x5 patches containing windmills"
   }


### PR DESCRIPTION
**Identified Issue**
For the `Patch_Select` puzzle type, we observe that some patches contain the target object but were not included in the ground truth in the original OpenCaptchaWorld paper. Visual labeling can be subjective, and disagreements between human annotators are sometimes unavoidable.

**Resolution**
PR #19 introduced "Optional Patches" in the original answer set for `Patch_Select` to address this issue. This PR further refines the definition and usage of optional patches to better handle incomplete or ambiguous human annotations.

Optional patches cover two scenarios:

1. Patches that contain the target object but were missed in the original OpenCaptchaWorld paper ground truth annotations.
2. Patches where visual evidence is ambiguous and reasonable annotators may disagree.

The goal is to preserve the benchmark’s ability to distinguish agent performance while allowing reasonable flexibility in cases of ambiguous human annotation. 

**Example (Puzzle ID 'Image2')**
As shown in the image below, patch 17 contains a visible butterfly segment but was not included in ground truth in the original OpenCaptchaWorld paper. It is therefore added to the optional_patches set to avoid penalizing agents that correctly identify it. In contrast, although patches 7 and 12 contain only small portions of the target object, these regions are still clearly identifiable as butterfly segments by a reasonable human annotator and are therefore excluded from the optional patches set to maintain evaluation strictness.
<img width="954" height="1028" alt="butterfly" src="https://github.com/user-attachments/assets/fe0bcc2b-4d0a-4f4d-87a7-8baad569717e" />