### PR TITLE
Fix patch select 2, and #16, #17, #18 and dart_puzzle_9 (#19)

### DIFF
--- a/assets/opencaptchaworld/data/Dart_Count/ground_truth.json
+++ b/assets/opencaptchaworld/data/Dart_Count/ground_truth.json
@@ -295,6 +295,7 @@
       "4darts_3.png"
     ],
     "correct_option_index": 6,
+    "correct_option_indices": [6, 9],
     "prompt": "Use the arrows to pick the image where all the darts add up to the number in the left image.",
     "description": "Dart counting puzzle where players need to find the image with darts that add up to the reference number",
     "dart_sums": {

--- a/assets/opencaptchaworld/data/Object_Match/ground_truth.json
+++ b/assets/opencaptchaworld/data/Object_Match/ground_truth.json
@@ -128,7 +128,7 @@
       "image15.png", 
       "image18.png"
     ],
-    "correct_option_index": 0,
+    "correct_option_index": 1,
     "prompt": "Use the arrows to change the number of objects until it matches the left image."
   },
   "example12.png": {

--- a/assets/opencaptchaworld/data/Patch_Select/ground_truth.json
+++ b/assets/opencaptchaworld/data/Patch_Select/ground_truth.json
@@ -10,6 +10,7 @@
     "target_object": "butterfly",
     "grid_size": [5, 5],
     "correct_patches": [5,6,7,10,11,12,15,16],
+    "optional_patches": [7, 12, 17],
     "prompt": "Select all squares with butterfly",
     "description": "A grid of 5x5 patches containing a butterfly"
   },

--- a/assets/opencaptchaworld/data/Slide_Puzzle/ground_truth.json
+++ b/assets/opencaptchaworld/data/Slide_Puzzle/ground_truth.json
@@ -248,7 +248,7 @@
       303,
       418
     ],
-    "tolerance": 15
+    "tolerance": 30
   },
   "slide30.png": {
     "answer": [

--- a/assets/opencaptchaworld/data/Unusual_Detection/ground_truth.json
+++ b/assets/opencaptchaworld/data/Unusual_Detection/ground_truth.json
@@ -149,7 +149,7 @@
   "unusual22.png": {
     "prompt": "Select the animal with the wrong head",
     "description": "Grid of animal images where some have mismatched heads/bodies",
-    "answer": [0,3,4],
+    "answer": [2],
     "grid_size": [2,3],
     "tolerance": 5
   },

--- a/scenarios/opencaptchaworld/opencaptchaworld_judge.py
+++ b/scenarios/opencaptchaworld/opencaptchaworld_judge.py
@@ -301,8 +301,13 @@ def check_answer(puzzle_type: str, puzzle_id: str, user_answer, ground_truth_dat
     
     elif puzzle_type in ['Unusual_Detection', 'Patch_Select', 'Select_Animal']:
         correct_cells = ground_truth_data.get('correct_patches', ground_truth_data.get('answer', []))
+        optional_cells = ground_truth_data.get('optional_patches', [])
         try:
             logger.info(f"Checking {puzzle_type}: user_answer={user_answer} (type={type(user_answer)}), correct_cells={correct_cells} (type={type(correct_cells)})")
+            if optional_cells:
+                # If optional cells exist, remove all optional cells from both user answer and correct cells
+                user_answer = [cell for cell in user_answer if cell not in optional_cells]
+                correct_cells = [cell for cell in correct_cells if cell not in optional_cells]
             is_correct = set(user_answer) == set(correct_cells)
             logger.info(f"Result: {is_correct}")
             return is_correct, correct_cells
@@ -333,6 +338,11 @@ def check_answer(puzzle_type: str, puzzle_id: str, user_answer, ground_truth_dat
     elif puzzle_type in ['Image_Matching', 'Dart_Count', 'Object_Match', 'Coordinates']:
         correct_index = ground_truth_data.get('correct_option_index')
         try:
+            if 'correct_option_indices' in ground_truth_data:
+                correct_indices = ground_truth_data.get('correct_option_indices', [-1])
+                for idx in correct_indices:
+                    if int(user_answer) == idx:
+                        return True, correct_indices
             user_index = int(user_answer)
             is_correct = user_index == correct_index
             return is_correct, correct_index

--- a/scenarios/opencaptchaworld/pseudo_purple_data/Object_Match/example11.png.json
+++ b/scenarios/opencaptchaworld/pseudo_purple_data/Object_Match/example11.png.json
@@ -1,7 +1,7 @@
 {
   "puzzle_type": "Object_Match",
   "puzzle_id": "example11.png",
-  "answer": 0,
+  "answer": 1,
   "elapsed_time": 0.5,
   "timestamp": "2025-11-23T22:35:57.733689"
 }

--- a/scenarios/opencaptchaworld/pseudo_purple_data/Unusual_Detection/unusual22.png.json
+++ b/scenarios/opencaptchaworld/pseudo_purple_data/Unusual_Detection/unusual22.png.json
@@ -2,9 +2,7 @@
   "puzzle_type": "Unusual_Detection",
   "puzzle_id": "unusual22.png",
   "answer": [
-    0,
-    3,
-    4
+    2
   ],
   "elapsed_time": 0.5,
   "timestamp": "2025-11-23T22:35:57.711215"


### PR DESCRIPTION
* Add additional answer option for bingo11 puzzle

* Add support for optional patches in Patch_Select validation

* fix typos

* fix #17: Slide_Puzzle: "slide29.png" ground truth answer not accurate

* fix #18: Unusual_Detection: "unusual22.png" gound truth not correct. Correct answer is [2]

* fix #18: Unusual_Detection: "unusual22.png" gound truth not correct. Correct answer is [2]

* Add support for multiple correct options in Dart_Count puzzles; fix dart_puzzle_9